### PR TITLE
fix character limit being shown as warning for fulltext editor text

### DIFF
--- a/utils/srt.py
+++ b/utils/srt.py
@@ -974,11 +974,11 @@ class SRTEditor:
                         )
                         text_color = "text-gray-500"
 
-                        tooltip_text = "Character count." if self.data_format == txt else "Character count. Max 42 per line (guideline)."
+                        tooltip_text = "Character count." if self.data_format == "txt" else "Character count. Max 42 per line (guideline)."
 
                         character_label = ""
                         for x in caption.text.split("\n"):
-                            if len(x) > CHARACTER_LIMIT & self.data_format != "txt":
+                            if len(x) > CHARACTER_LIMIT and self.data_format != "txt":
                                 text_color = CHARACTER_LIMIT_EXCEEDED_COLOR
                                 tooltip_text = (
                                     f"Character limit of {CHARACTER_LIMIT} exceeded in one or more lines."


### PR DESCRIPTION
Check if we are in fulltext mode before using warning color for character count and set tooltip accordingly.