### PR TITLE
Fix non admin_domains crash in user provision rule creation

### DIFF
--- a/pages/admin.py
+++ b/pages/admin.py
@@ -1516,7 +1516,7 @@ def create_rule_dialog(page: callable) -> None:
 
     if not is_bofh:
         user_data = get_user_data() or {}
-        admin_domains = user_data.get("admin_domains", "")
+        admin_domains = user_data.get("admin_domains") or ""
         allowed_realms = [
             d.strip() for d in admin_domains.split(",") if d.strip() and "." in d.strip()
         ]


### PR DESCRIPTION
Creating a user provisioning rule as an admin with no domain assigned will cause an error because admin_domains is NONE.
This changes the value to an empty string instead of NONE so the split() won't crash the interface.

`    d.strip() for d in admin_domains.split(",") if d.strip() and "." in d.strip()
                       ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'`