### PR TITLE
Bugfix malloc upload

### DIFF
--- a/pages/home.py
+++ b/pages/home.py
@@ -219,4 +219,10 @@ def create() -> None:
             )
             poll_timer.interval = 5.0 if has_active else 30.0
 
-                ui.timer(0.0, initial_load, once=True)
+        async def initial_load():
+            rows = await jobs_get()
+            table.rows = rows
+            table.selection = "multiple" if rows else "none"
+
+        poll_timer = ui.timer(30.0, update_rows)
+        ui.timer(0.0, initial_load, once=True)

--- a/pages/home.py
+++ b/pages/home.py
@@ -196,8 +196,14 @@ def create() -> None:
         async def update_rows():
             """
             Update the rows in the table.
+
+            Avoid clearing the existing table during temporary backend/API failures.
+            This can happen while large uploads are being stored and encrypted.
             """
             rows = await jobs_get()
+
+            if not rows and table.rows:
+                return
 
             if not rows:
                 delete.set_enabled(False)
@@ -213,10 +219,4 @@ def create() -> None:
             )
             poll_timer.interval = 5.0 if has_active else 30.0
 
-        poll_timer = ui.timer(30.0, update_rows, active=False)
-
-        async def initial_load():
-            poll_timer.activate()
-            await update_rows()
-
-        ui.timer(0.0, initial_load, once=True)
+                ui.timer(0.0, initial_load, once=True)

--- a/utils/common.py
+++ b/utils/common.py
@@ -34,9 +34,8 @@ from utils.token import (
 )
 from utils.helpers import storage_decrypt, customers_get
 
-MultiPartParser.spool_max_size = 1024 * 1024 * 4096
 settings = get_settings()
-
+MultiPartParser.spool_max_size = 1024 * 1024 * settings.MULTIPART_SPOOL_MAX_SIZE_MB
 
 def sanitize_filename(filename: str) -> str:
     """

--- a/utils/common.py
+++ b/utils/common.py
@@ -1044,7 +1044,6 @@ async def handle_upload_with_feedback(files, dialog, table):
 
     dialog.close()
 
-    # Read file data while the client context is still active
     file_items = []
 
     for file in files.files:
@@ -1063,44 +1062,43 @@ async def handle_upload_with_feedback(files, dialog, table):
             file_items.append((file_name, temp_path))
         except Exception:
             if os.path.exists(temp_path):
-            os.remove(temp_path)
-        raise
+                os.remove(temp_path)
+            raise
 
-# Upload to backend in a background task so the UI stays responsive
-async def _upload():
-    for file_name, temp_path in file_items:
-        try:
-            success = await post_file(temp_path, file_name)
+    async def _upload():
+        for file_name, temp_path in file_items:
+            try:
+                success = await post_file(temp_path, file_name)
 
-            if not client._deleted:
-                if success:
+                if not client._deleted:
+                    if success:
+                        ui.notify(
+                            f"Successfully uploaded {file_name}",
+                            type="positive",
+                            timeout=3000,
+                        )
+                    else:
+                        ui.notify(
+                            f"Error uploading {file_name}",
+                            type="negative",
+                            timeout=5000,
+                        )
+            except Exception as e:
+                if not client._deleted:
                     ui.notify(
-                        f"Successfully uploaded {file_name}",
-                        type="positive",
-                        timeout=3000,
-                    )
-                else:
-                    ui.notify(
-                        f"Error uploading {file_name}",
+                        f"Error uploading {file_name}: {str(e)}",
                         type="negative",
                         timeout=5000,
                     )
-        except Exception as e:
-            if not client._deleted:
-                ui.notify(
-                    f"Error uploading {file_name}: {str(e)}",
-                    type="negative",
-                    timeout=5000,
-                )
-        finally:
-            if os.path.exists(temp_path):
-                os.remove(temp_path)
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
 
-    if not client._deleted:
-        await client.connected()
-        table.update_rows(await jobs_get(), clear_selection=False)
+        if not client._deleted:
+            await client.connected()
+            table.update_rows(await jobs_get(), clear_selection=False)
 
-asyncio.create_task(_upload())
+    asyncio.create_task(_upload())
 
 
 def table_transcribe(selected_row, on_complete=None) -> None:

--- a/utils/common.py
+++ b/utils/common.py
@@ -1115,7 +1115,8 @@ async def handle_upload_with_feedback(files, dialog, table, status_label):
         if not client._deleted:
             rows = await jobs_get()
             with client:
-                table.update_rows(rows, clear_selection=False)
+                if rows or not table.rows:
+                    table.update_rows(rows, clear_selection=False)
                 dialog.close()
 
     asyncio.create_task(_upload())

--- a/utils/common.py
+++ b/utils/common.py
@@ -936,7 +936,7 @@ def table_upload(table) -> None:
                     ui.upload(
                         label="hidden",
                         on_multi_upload=lambda e: handle_upload_with_feedback(
-                            e, dialog, table
+                            e, dialog, table, status_label
                         ),
                         auto_upload=True,
                         multiple=True,
@@ -956,7 +956,10 @@ def table_upload(table) -> None:
                         upload_column, status_column, dialog
                     ),
                 )
-                upload.on("finish", lambda _: dialog.close())
+                upload.on(
+                    "finish",
+                    lambda _: status_label.set_text("Finishing upload, please wait..."),
+                )
 
                 def on_byte_progress(e):
                     uploaded = e.args.get("uploaded", 0)
@@ -1035,19 +1038,26 @@ def table_upload(table) -> None:
         dialog.open()
 
 
-async def handle_upload_with_feedback(files, dialog, table):
+async def handle_upload_with_feedback(files, dialog, table, status_label):
     """
     Handle file uploads with user feedback and validation.
+
+    The NiceGUI upload progress only covers browser -> UI.
+    This function keeps the dialog open while the UI forwards the file to the backend.
     """
 
     client = ui.context.client
 
-    dialog.close()
-
     file_items = []
+    total = len(files.files)
 
-    for file in files.files:
+    for index, file in enumerate(files.files, 1):
         file_name = sanitize_filename(file.name)
+
+        if not client._deleted:
+            status_label.set_text(
+                f"Saving file {index} of {total} locally: {file_name}"
+            )
 
         temp_file = tempfile.NamedTemporaryFile(
             delete=False,
@@ -1066,8 +1076,14 @@ async def handle_upload_with_feedback(files, dialog, table):
             raise
 
     async def _upload():
-        for file_name, temp_path in file_items:
+        for index, (file_name, temp_path) in enumerate(file_items, 1):
             try:
+                if not client._deleted:
+                    with client:
+                        status_label.set_text(
+                            f"Storing and encrypting file {index} of {total}: {file_name}"
+                        )
+
                 success = await post_file(temp_path, file_name)
 
                 if not client._deleted:
@@ -1097,8 +1113,10 @@ async def handle_upload_with_feedback(files, dialog, table):
                     os.remove(temp_path)
 
         if not client._deleted:
+            rows = await jobs_get()
             with client:
-                table.update_rows(await jobs_get(), clear_selection=False)
+                table.update_rows(rows, clear_selection=False)
+                dialog.close()
 
     asyncio.create_task(_upload())
 

--- a/utils/common.py
+++ b/utils/common.py
@@ -16,7 +16,9 @@
 # limitations under the License.
 
 import asyncio
+import os
 import re
+import tempfile
 import httpx
 import pytz
 
@@ -855,20 +857,26 @@ def table_click(event) -> None:
         )
 
 
-async def post_file(filedata: bytes, filename: str) -> bool:
+async def post_file(file_path: str, filename: str) -> bool:
     """
-    Post a file to the API.
+    Stream a file from disk to the API without loading it into memory.
     """
-
-    files_json = {"file": (filename, filedata)}
 
     try:
         async with httpx.AsyncClient(timeout=900) as client:
-            response = await client.post(
-                f"{settings.API_URL}/api/v1/transcriber",
-                files=files_json,
-                headers=get_auth_header(),
-            )
+            with open(file_path, "rb") as upload_file:
+                response = await client.post(
+                    f"{settings.API_URL}/api/v1/transcriber",
+                    files={
+                        "file": (
+                            filename,
+                            upload_file,
+                            "application/octet-stream",
+                        )
+                    },
+                    headers=get_auth_header(),
+                )
+
             response.raise_for_status()
 
             if response.status_code != 200:
@@ -1038,37 +1046,61 @@ async def handle_upload_with_feedback(files, dialog, table):
 
     # Read file data while the client context is still active
     file_items = []
+
     for file in files.files:
         file_name = sanitize_filename(file.name)
-        file_data = await file.read()
-        file_items.append((file_name, file_data))
 
-    # Upload to backend in a background task so the UI stays responsive
-    async def _upload():
-        for file_name, file_data in file_items:
-            try:
-                await post_file(file_data, file_name)
+        temp_file = tempfile.NamedTemporaryFile(
+            delete=False,
+            prefix="scribe-ui-upload-",
+            suffix=".upload",
+        )
+        temp_path = temp_file.name
+        temp_file.close()
 
-                if not client._deleted:
-                    with table:
-                        ui.notify(
-                            f"Successfully uploaded {file_name}",
-                            type="positive",
-                            timeout=3000,
-                        )
-            except Exception as e:
-                if not client._deleted:
-                    with table:
-                        ui.notify(
-                            f"Error uploading {file_name}: {str(e)}",
-                            type="negative",
-                            timeout=5000,
-                        )
+        try:
+            await file.save(temp_path)
+            file_items.append((file_name, temp_path))
+        except Exception:
+            if os.path.exists(temp_path):
+            os.remove(temp_path)
+        raise
 
-        if not client._deleted:
-            table.update_rows(await jobs_get(), clear_selection=False)
+# Upload to backend in a background task so the UI stays responsive
+async def _upload():
+    for file_name, temp_path in file_items:
+        try:
+            success = await post_file(temp_path, file_name)
 
-    asyncio.create_task(_upload())
+            if not client._deleted:
+                if success:
+                    ui.notify(
+                        f"Successfully uploaded {file_name}",
+                        type="positive",
+                        timeout=3000,
+                    )
+                else:
+                    ui.notify(
+                        f"Error uploading {file_name}",
+                        type="negative",
+                        timeout=5000,
+                    )
+        except Exception as e:
+            if not client._deleted:
+                ui.notify(
+                    f"Error uploading {file_name}: {str(e)}",
+                    type="negative",
+                    timeout=5000,
+                )
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    if not client._deleted:
+        await client.connected()
+        table.update_rows(await jobs_get(), clear_selection=False)
+
+asyncio.create_task(_upload())
 
 
 def table_transcribe(selected_row, on_complete=None) -> None:

--- a/utils/common.py
+++ b/utils/common.py
@@ -1071,32 +1071,34 @@ async def handle_upload_with_feedback(files, dialog, table):
                 success = await post_file(temp_path, file_name)
 
                 if not client._deleted:
-                    if success:
+                    with client:
+                        if success:
+                            ui.notify(
+                                f"Successfully uploaded {file_name}",
+                                type="positive",
+                                timeout=3000,
+                            )
+                        else:
+                            ui.notify(
+                                f"Error uploading {file_name}",
+                                type="negative",
+                                timeout=5000,
+                            )
+            except Exception as e:
+                if not client._deleted:
+                    with client:
                         ui.notify(
-                            f"Successfully uploaded {file_name}",
-                            type="positive",
-                            timeout=3000,
-                        )
-                    else:
-                        ui.notify(
-                            f"Error uploading {file_name}",
+                            f"Error uploading {file_name}: {str(e)}",
                             type="negative",
                             timeout=5000,
                         )
-            except Exception as e:
-                if not client._deleted:
-                    ui.notify(
-                        f"Error uploading {file_name}: {str(e)}",
-                        type="negative",
-                        timeout=5000,
-                    )
             finally:
                 if os.path.exists(temp_path):
                     os.remove(temp_path)
 
         if not client._deleted:
-            await client.connected()
-            table.update_rows(await jobs_get(), clear_selection=False)
+            with client:
+                table.update_rows(await jobs_get(), clear_selection=False)
 
     asyncio.create_task(_upload())
 

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -38,6 +38,8 @@ class Settings(BaseSettings):
     OIDC_APP_REFRESH_ROUTE: str = ""
     STORAGE_SECRET: str = "change_this_secret_to_another_very_secret_secret"
 
+    MULTIPART_SPOOL_MAX_SIZE_MB: int = 4096
+
     LOGO_LANDING: str = "sunet_logo.png"
     LOGO_LANDING_WIDTH: str = "250"
     LOGO_TOPBAR: str = "sunet_small.png"


### PR DESCRIPTION
## Summary

This PR improves large file upload handling and makes the upload UI more reliable while files are being stored and processed by the backend.

The main change is that uploaded files are no longer read fully into memory before being sent to the backend. Instead, uploads are saved temporarily to disk and streamed from there. This reduces memory pressure and avoids malloc/RAM issues when uploading large files.

## Main changes

- Stream uploaded files from temporary disk files instead of loading them fully into memory.
- Clean up temporary upload files after each upload attempt.
- Make the multipart spool size configurable via settings.
- Keep the upload dialog open until the backend upload/storage step has completed.
- Improve upload status messages so users can see when files are being saved locally and when they are being stored/encrypted by the backend.
- Avoid clearing the jobs table during temporary empty responses from the backend, which can happen while large uploads are being processed.
- Restore initial table loading and polling behavior after the table refresh changes.

## Why

Large uploads could previously cause excessive memory usage because files were handled as in-memory byte objects. This PR changes the upload flow to be disk-backed, making uploads more robust for large files and improving the user experience during longer upload/storage operations.