### PR TITLE
store rotated refresh token

### DIFF
--- a/utils/token.py
+++ b/utils/token.py
@@ -37,7 +37,13 @@ def token_refresh_call() -> str:
     except httpx.HTTPError:
         return None
 
-    return response.json().get("access_token")
+    token_response = response.json()
+
+    new_refresh_token = token_response.get("refresh_token")
+    if new_refresh_token:
+        app.storage.user["refresh_token"] = new_refresh_token
+
+    return token_response.get("access_token")
 
 
 def token_refresh() -> bool:


### PR DESCRIPTION
Support refresh token rotation during OIDC token refresh

Return refresh_token from the refresh endpoint when supplied by the OIDC
provider, and update the stored user refresh token on the client side.
This keeps the app compatible with providers that rotate refresh tokens
and invalidate the previous token after use.

This resolves an issue where users were getting logged out because they would use an old refresh token.